### PR TITLE
Fixed unicode issues

### DIFF
--- a/default.py
+++ b/default.py
@@ -112,7 +112,7 @@ def normalize(d, key = None, default = ""):
         if not text:
             return text
     try:
-        text = unicodedata.normalize('NFKD', _unicode(text)).encode('ascii', 'ignore')
+        text = unicodedata.normalize('NFKD', _unicode(text))
     except:
         pass
     return text


### PR DESCRIPTION
Encoding to ascii with 'replace' fallback makes no sense for some languages. I.e. the script may search for empty strings due to this behavior.